### PR TITLE
ページ遷移設定（/about）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # kokuraex
+
+# About
+
+This is kokura.ex org site.
+
+## Routes
+
+```
+$ docker-compose exec app mix phx.routes
+
+          page_path  GET  /                                      KokuraExWeb.PageController :index
+         about_path  GET  /about                                 KokuraExWeb.AboutController :index
+```

--- a/app/lib/kokura_ex_web/controllers/about_controller.ex
+++ b/app/lib/kokura_ex_web/controllers/about_controller.ex
@@ -1,0 +1,7 @@
+defmodule KokuraExWeb.AboutController do
+  use KokuraExWeb, :controller
+
+  def index(conn, _params) do
+    render(conn, "index.html")
+  end
+end

--- a/app/lib/kokura_ex_web/router.ex
+++ b/app/lib/kokura_ex_web/router.ex
@@ -17,6 +17,7 @@ defmodule KokuraExWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    get "/about", AboutController, :index
   end
 
   # Other scopes may use custom stacks.

--- a/app/lib/kokura_ex_web/templates/about/index.html.eex
+++ b/app/lib/kokura_ex_web/templates/about/index.html.eex
@@ -1,0 +1,6 @@
+<section class="phx-hero">
+  <h1>About</h1>
+</section>
+<section class="row">
+  <p>WIP</p>
+</section>

--- a/app/lib/kokura_ex_web/views/about_view.ex
+++ b/app/lib/kokura_ex_web/views/about_view.ex
@@ -1,0 +1,3 @@
+defmodule KokuraExWeb.AboutView do
+  use KokuraExWeb, :view
+end

--- a/app/test/kokura_ex_web/controllers/page_controller_test.exs
+++ b/app/test/kokura_ex_web/controllers/page_controller_test.exs
@@ -5,4 +5,9 @@ defmodule KokuraExWeb.PageControllerTest do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "Welcome to Phoenix!"
   end
+
+  test "GET /about", %{conn: conn} do
+    conn = get(conn, "/about")
+    assert html_response(conn, 200) =~ "About"
+  end
 end


### PR DESCRIPTION
以下の案の`/about`該当部分のルートを新規作成する

| |概要|説明|
| :-- | :-- | :-- |
|/index|トップページ|- 簡単なabout<br>- プロジェクト目的|
|/about|紹介|- kokura.ex自体（connpassに書いてることをそのまま引用）<br>- 管理人（im）|
|/tools|使用ツール類|- Slack<br>- Zapier<br>- Discord|

- closed: https://github.com/miolab/kokuraex/issues/2