### PR TITLE
linkパスを追加（Home, About）

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,11 @@ $ docker-compose exec app mix phx.routes
 
           page_path  GET  /                                      KokuraExWeb.PageController :index
          about_path  GET  /about                                 KokuraExWeb.AboutController :index
+live_dashboard_path  GET  /dashboard                             Phoenix.LiveView.Plug :home
+live_dashboard_path  GET  /dashboard/:page                       Phoenix.LiveView.Plug :page
+live_dashboard_path  GET  /dashboard/:node/:page                 Phoenix.LiveView.Plug :page
+          websocket  WS   /live/websocket                        Phoenix.LiveView.Socket
+           longpoll  GET  /live/longpoll                         Phoenix.LiveView.Socket
+           longpoll  POST  /live/longpoll                         Phoenix.LiveView.Socket
+          websocket  WS   /socket/websocket                      KokuraExWeb.UserSocket
 ```

--- a/app/lib/kokura_ex_web/templates/layout/app.html.eex
+++ b/app/lib/kokura_ex_web/templates/layout/app.html.eex
@@ -25,6 +25,15 @@
       </section>
     </header>
     <main role="main" class="container">
+      <ul class="row" style="list-style: none;">
+        <li>
+          <%= link "Home", to: Routes.page_path(@conn, :index) %>
+          &nbsp;
+        </li>
+        <li>
+          <%= link "About", to: Routes.about_path(@conn, :index) %>
+        </li>
+      </ul>
       <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
       <%= @inner_content %>


### PR DESCRIPTION
### やったこと

HomeとAboutを行き来できるようlinkパスを追加（サイト上部）
- style はあとで決める

<img width="277" alt="スクリーンショット 2021-06-22 9 43 01" src="https://user-images.githubusercontent.com/33124627/122845292-560c1e80-d33e-11eb-8ee1-d3afa39ad1c1.png">

---

- ref: https://github.com/miolab/kokuraex/pull/8

  ```
  $ docker-compose exec app mix phx.routes

          page_path  GET  /                                      KokuraExWeb.PageController :index
         about_path  GET  /about                                 KokuraExWeb.AboutController :index
  ```