### PR TITLE
Eventページ「with Pelemay Meetup 」部へ表示させるイベントを追加

### DIFF
--- a/app/lib/kokuraex_web/controllers/event_controller.ex
+++ b/app/lib/kokuraex_web/controllers/event_controller.ex
@@ -10,11 +10,7 @@ defmodule KokuraexWeb.EventController do
           "kokura_ex",
           "5"
         ),
-      pelemay_events:
-        connpass_events(
-          "Pelemay Meetup SIMD勉強会",
-          "3"
-        )
+      pelemay_events: pelemay_connpass_events()
     )
   end
 
@@ -82,6 +78,38 @@ defmodule KokuraexWeb.EventController do
             )
         end
     end
+  end
+
+  def pelemay_connpass_events() do
+    [
+      pelemay_simd_meetup(),
+      pelemay_beam_otp_meetup(),
+      pelemay_history_meetup()
+    ]
+    |> Enum.concat()
+    |> Enum.sort_by(& &1.started_at, :desc)
+    |> Enum.take(5)
+  end
+
+  def pelemay_simd_meetup() do
+    connpass_events(
+      "Pelemay Meetup SIMD勉強会",
+      "3"
+    )
+  end
+
+  def pelemay_beam_otp_meetup() do
+    connpass_events(
+      "「BEAM/OTP対話」",
+      "3"
+    )
+  end
+
+  def pelemay_history_meetup() do
+    connpass_events(
+      "Pelemayの歴史を振り返る会",
+      "2"
+    )
   end
 
   def default_events_map() do

--- a/app/test/kokuraex_web/controllers/page_controller_test.exs
+++ b/app/test/kokuraex_web/controllers/page_controller_test.exs
@@ -103,4 +103,12 @@ defmodule KokuraexWeb.PageControllerTest do
 
     assert hd === expected
   end
+
+  test "test_pelemayのconnpassイベント数が意図した数値で取得できる" do
+    actual =
+      pelemay_connpass_events()
+      |> Enum.count()
+
+    assert actual == 5
+  end
 end


### PR DESCRIPTION
以下を追加した
- 「BEAM/OTP対話」
- Pelemayの歴史を振り返る会

ref: https://elixirjp.slack.com/archives/CPMB7CFPZ/p1636971970167200?thread_ts=1636971234.166400&cid=CPMB7CFPZ