### PR TITLE
[Event] 開催日時が未経過イベントについて赤文字で明示する機能追加

### DIFF
--- a/app/lib/kokuraex_web/controllers/event_functions/event_function.ex
+++ b/app/lib/kokuraex_web/controllers/event_functions/event_function.ex
@@ -69,6 +69,8 @@ defmodule KokuraexWeb.EventFunction do
                 | title: &1["title"],
                   started_at: &1["started_at"] |> datetime_from_iso8601() |> return_datetime(),
                   ended_at: &1["ended_at"] |> datetime_from_iso8601() |> return_datetime(),
+                  is_coming_date:
+                    &1["ended_at"] |> compare_date_with_current_jst_date() |> is_eq_or_gt_atom(),
                   catch: &1["catch"],
                   address: &1["address"],
                   event_url: &1["event_url"]
@@ -144,6 +146,7 @@ defmodule KokuraexWeb.EventFunction do
       title: "Not Found",
       started_at: "-",
       ended_at: "-",
+      is_coming_date: false,
       catch: "-",
       address: "-",
       event_url: "https://kokura-ex.herokuapp.com/"

--- a/app/lib/kokuraex_web/controllers/event_functions/event_function.ex
+++ b/app/lib/kokuraex_web/controllers/event_functions/event_function.ex
@@ -8,8 +8,8 @@ defmodule KokuraexWeb.EventFunction do
   @doc """
   GET event data from connmass API.
   """
-  def get_connpass_events(keyword, count) do
-    "https://connpass.com/api/v1/event/?keyword=#{keyword}&order=2&count=#{count}"
+  def get_connpass_events(keyword, nickname, count) do
+    "https://connpass.com/api/v1/event/?keyword=#{keyword}&nickname=#{nickname}&order=2&count=#{count}"
     |> HTTPoison.get()
   end
 
@@ -28,9 +28,9 @@ defmodule KokuraexWeb.EventFunction do
   @doc """
   Return array include connpass events Map.
   """
-  def connpass_events(keyword, count) do
+  def connpass_events(keyword, nickname, count) do
     res =
-      get_connpass_events(keyword, count)
+      get_connpass_events(keyword, nickname, count)
       |> handle_httpoison_result()
 
     case res do
@@ -84,6 +84,7 @@ defmodule KokuraexWeb.EventFunction do
   def kokuraex_connpass_events() do
     connpass_events(
       "kokura_ex",
+      "imlab",
       "5"
     )
   end
@@ -108,6 +109,7 @@ defmodule KokuraexWeb.EventFunction do
   def pelemay_simd_meetup() do
     connpass_events(
       "Pelemay Meetup SIMD勉強会",
+      "zacky1972",
       "3"
     )
   end
@@ -118,6 +120,7 @@ defmodule KokuraexWeb.EventFunction do
   def pelemay_beam_otp_meetup() do
     connpass_events(
       "「BEAM/OTP対話」",
+      "zacky1972",
       "3"
     )
   end
@@ -128,6 +131,7 @@ defmodule KokuraexWeb.EventFunction do
   def pelemay_history_meetup() do
     connpass_events(
       "Pelemayの歴史を振り返る会",
+      "zacky1972",
       "2"
     )
   end

--- a/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
+++ b/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
@@ -14,9 +14,9 @@ defmodule KokuraexWeb.DatetimeFunction do
   @doc """
   JST日時 {:ok, ~N[2021-01-01 00:00:00]} 形式を、"2021-01-01 00:00(JST)" 文字列に置換する
   """
-  def return_datetime({:ok, body}) do
+  def return_datetime({:ok, naive}) do
     datetime =
-      body
+      naive
       |> NaiveDateTime.to_string()
 
     Regex.replace(~r/:\d{2}$/, datetime, "(JST)")
@@ -25,10 +25,28 @@ defmodule KokuraexWeb.DatetimeFunction do
   def return_datetime({:error, _}), do: "0000-00-00 00:00(JST)"
 
   @doc """
-  現在のJST時刻を取得する
+  現在のJST時刻を取得してISO8601形式で返す
   """
   def current_jst_datetime() do
     Timex.now("Japan")
     |> DateTime.to_iso8601()
+  end
+
+  @doc """
+  ISO8601形式を持つ特定の日時をJST現在日時と日付比較し結果を返す
+  """
+  def compare_date_with_current_jst_date(datetime_iso8601) do
+    {:ok, naive} =
+      datetime_iso8601
+      |> datetime_from_iso8601()
+
+    {:ok, current_jst_date} =
+      current_jst_datetime()
+      |> datetime_from_iso8601()
+
+    Date.compare(
+      naive |> NaiveDateTime.to_date(),
+      current_jst_date |> NaiveDateTime.to_date()
+    )
   end
 end

--- a/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
+++ b/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
@@ -23,4 +23,12 @@ defmodule KokuraexWeb.DatetimeFunction do
   end
 
   def return_datetime({:error, _}), do: "0000-00-00 00:00(JST)"
+
+  @doc """
+  現在のJST時刻を取得する
+  """
+  def current_jst_datetime() do
+    Timex.now("Japan")
+    |> DateTime.to_iso8601()
+  end
 end

--- a/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
+++ b/app/lib/kokuraex_web/controllers/util_functions/datetime_function.ex
@@ -49,4 +49,11 @@ defmodule KokuraexWeb.DatetimeFunction do
       current_jst_date |> NaiveDateTime.to_date()
     )
   end
+
+  @doc """
+  :eqか:gtならtrue、:ltならfalseを返す
+  """
+  def is_eq_or_gt_atom(:eq), do: true
+  def is_eq_or_gt_atom(:gt), do: true
+  def is_eq_or_gt_atom(:lt), do: false
 end

--- a/app/lib/kokuraex_web/templates/event/index.html.heex
+++ b/app/lib/kokuraex_web/templates/event/index.html.heex
@@ -3,18 +3,20 @@
     Event
   </h1>
   <div class="flex flex-col text-center mt-8">
-    <div class="flex flex-col mt-3">
+    <div class="flex flex-col mt-3 mb-4">
       <h1 class="text-2xl">
         kokura.ex / fukuoka.ex
       </h1>
       <%= for event <- @kokura_events do %>
         <div class="m-4 p-3 rounded-lg bg-gray-100 text-blue-900 text-left">
-          <div class="mb-1 flex justify-between text-sm">
-            <span>
-              開催日時 <%= event.started_at %> ~ <%= event.ended_at %>
-            </span>
-            <span>
-              <%= event.address %>
+          <div class="mb-1">
+            <%= if event.is_coming_date === true do %>
+              <span class="font-bold text-red-500">開催日時</span>
+            <% else %>
+              <span class="font-bold">開催日時</span>
+            <% end %>
+            <span class="ml-2">
+              <%= event.started_at %> ~ <%= event.ended_at %>
             </span>
           </div>
           <div class="mb-2 text-xl font-bold text-purple-900">
@@ -29,21 +31,26 @@
           <div class="text-sm">
             <%= event.catch %>
           </div>
+          <div class="text-sm text-right">
+            <%= event.address %>
+          </div>
         </div>
       <% end %>
     </div>
-    <div class="flex flex-col mt-3">
+    <div class="flex flex-col mt-3 mb-4">
       <h1 class="text-2xl">
         with Pelemay Meetup
       </h1>
       <%= for event <- @pelemay_events do %>
         <div class="m-4 p-3 rounded-lg bg-gray-100 text-blue-900 text-left">
-          <div class="mb-1 flex justify-between text-sm">
-            <span>
-              開催日時 <%= event.started_at %> ~ <%= event.ended_at %>
-            </span>
-            <span>
-              <%= event.address %>
+          <div class="mb-1">
+            <%= if event.is_coming_date === true do %>
+              <span class="font-bold text-red-500">開催日時</span>
+            <% else %>
+              <span class="font-bold">開催日時</span>
+            <% end %>
+            <span class="ml-2">
+              <%= event.started_at %> ~ <%= event.ended_at %>
             </span>
           </div>
           <div class="mb-2 text-xl font-bold text-purple-900">
@@ -57,6 +64,9 @@
           </div>
           <div class="text-sm">
             <%= event.catch %>
+          </div>
+          <div class="text-sm text-right">
+            <%= event.address %>
           </div>
         </div>
       <% end %>

--- a/app/test/kokuraex_web/controllers/event_functions/event_function_test.exs
+++ b/app/test/kokuraex_web/controllers/event_functions/event_function_test.exs
@@ -38,6 +38,7 @@ defmodule KokuraexWeb.EventFunctionTest do
     address: "-",
     catch: "-",
     ended_at: "-",
+    is_coming_date: false,
     event_url: "https://kokura-ex.herokuapp.com/",
     started_at: "-",
     title: "Not Found"
@@ -88,6 +89,7 @@ defmodule KokuraexWeb.EventFunctionTest do
         address: "-",
         catch: "-",
         ended_at: "-",
+        is_coming_date: false,
         event_url: "https://kokura-ex.herokuapp.com/",
         started_at: "-",
         title: "No events found"

--- a/app/test/kokuraex_web/controllers/event_functions/event_function_test.exs
+++ b/app/test/kokuraex_web/controllers/event_functions/event_function_test.exs
@@ -4,7 +4,7 @@ defmodule KokuraexWeb.EventFunctionTest do
 
   test "test_HTTPoisonでconnpass APIに対してkeyword=kokura_exで叩いてGETできる" do
     result =
-      get_connpass_events("kokura_ex", "2")
+      get_connpass_events("kokura_ex", "imlab", "2")
       |> elem(0)
 
     assert result === :ok
@@ -48,7 +48,7 @@ defmodule KokuraexWeb.EventFunctionTest do
   end
 
   test "test_kokura.exのconnpassイベントが取得できる（該当イベント数が1件のケース）" do
-    result = connpass_events("kokura_ex", "1")
+    result = connpass_events("kokura_ex", "imlab", "1")
 
     assert Enum.count(result) == 1
 
@@ -62,7 +62,7 @@ defmodule KokuraexWeb.EventFunctionTest do
   end
 
   test "test_kokura.exのconnpassイベントが取得できる（該当イベント数が2件以上のケース）" do
-    result = connpass_events("kokura_ex", "3")
+    result = connpass_events("kokura_ex", "imlab", "3")
 
     assert Enum.count(result) == 3
 
@@ -79,6 +79,7 @@ defmodule KokuraexWeb.EventFunctionTest do
     actual =
       connpass_events(
         "hard_to_exist_event_keyword_foo_bar_foo_bar",
+        "hard_to_exist_too_long_named_person_foo_bar_foo_bar",
         "3"
       )
 

--- a/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
+++ b/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
@@ -72,4 +72,10 @@ defmodule KokuraexWeb.DatetimeFunctionTest do
     actual = compare_date_with_current_jst_date("3000-01-01T00:00:00+09:00")
     assert actual == :gt
   end
+
+  test "test_`:eq`か`:gt`ならtrue、`:lt`ならfalseを返す" do
+    assert is_eq_or_gt_atom(:eq) === true
+    assert is_eq_or_gt_atom(:gt) === true
+    assert is_eq_or_gt_atom(:lt) === false
+  end
 end

--- a/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
+++ b/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
@@ -30,4 +30,36 @@ defmodule KokuraexWeb.DatetimeFunctionTest do
 
     assert actual === "0000-00-00 00:00(JST)"
   end
+
+  defp current_jst_naivedatetime() do
+    {:ok, naive} =
+      current_jst_datetime()
+      |> NaiveDateTime.from_iso8601()
+
+    naive
+  end
+
+  test "test_取得したJST現在時刻がNaiveDateTime形式であることを保証する" do
+    # FIXME: 暫定的に、西暦4桁年/1or2桁月/分のパラメータを持っていることでジャッジしている
+    has_year =
+      current_jst_naivedatetime().year
+      |> Integer.to_string()
+      |> String.match?(~r/\d{4}/)
+
+    assert has_year === true
+
+    has_month =
+      current_jst_naivedatetime().month
+      |> Integer.to_string()
+      |> String.match?(~r/[1-9]|1[0-2]/)
+
+    assert has_month === true
+
+    has_minute =
+      current_jst_naivedatetime().minute
+      |> Integer.to_string()
+      |> String.match?(~r/[0-5]?\d/)
+
+    assert has_minute === true
+  end
 end

--- a/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
+++ b/app/test/kokuraex_web/controllers/util_functions/datetime_function_test.exs
@@ -62,4 +62,14 @@ defmodule KokuraexWeb.DatetimeFunctionTest do
 
     assert has_minute === true
   end
+
+  test "test_ISO8601形式を持つ特定の日時がJST現在日時より過去の日付だったらltを返す" do
+    actual = compare_date_with_current_jst_date("2000-01-01T00:00:00+09:00")
+    assert actual == :lt
+  end
+
+  test "test_ISO8601形式を持つ特定の日時がJST現在日時より未来の日付だったらgtを返す" do
+    actual = compare_date_with_current_jst_date("3000-01-01T00:00:00+09:00")
+    assert actual == :gt
+  end
 end


### PR DESCRIPTION
# やったこと
| |イメージ|
|:--|:--|
|before|<img width="761" alt="スクリーンショット 2021-11-21 10 06 00" src="https://user-images.githubusercontent.com/33124627/142745424-c8570bca-9372-4215-ae37-aa95aba3f274.png">|
|after|<img width="774" alt="スクリーンショット 2021-11-21 10 06 07" src="https://user-images.githubusercontent.com/33124627/142745427-23f34cc0-69a9-4f8b-84c6-4c52a877e6be.png">|
1. 表題の機能を実装した
2. 開催場所（オンライン、etc.）の表示箇所を上部→下部へ変更した
3. フォント大きさなど細かい部分を変更した
4. GETするイベントを、管理者が実際に参加しているイベントのみに絞るよう条件変更した
  - 関わりないイベントの誤検知を防止するため