### PR TITLE
update/ Elixir version to 1.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ end
 
 ## Versions
 
-- Elixir 1.18.1 (Erlang/OTP 27)
+- Elixir 1.18.3 (Erlang/OTP 27)
 - Phoenix 1.7.18
 
 ## CI/CD tool

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.18.1-slim AS build
+FROM elixir:1.18.3-slim AS build
 
 ENV MIX_HOME=/root/.mix \
   MIX_ENV=prod \
@@ -37,7 +37,7 @@ RUN MIX_ENV=prod mix deps.compile
 RUN MIX_ENV=prod mix assets.deploy
 RUN MIX_ENV=prod mix release --overwrite
 
-FROM elixir:1.18.1-slim AS app
+FROM elixir:1.18.3-slim AS app
 
 ENV HOME=/app \
   PHX_SERVER=true

--- a/app/Dockerfile.dev
+++ b/app/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM elixir:1.18.1-slim
+FROM elixir:1.18.3-slim
 
 ENV MIX_HOME=/root/.mix \
   MIX_ENV=dev \

--- a/app/lib/kokuraex_web/components/layouts/root.html.heex
+++ b/app/lib/kokuraex_web/components/layouts/root.html.heex
@@ -70,7 +70,7 @@
           <span class="ml-3 text-xl">kokura.ex</span>
         </.link>
         <p class="text-sm text-gray-600 sm:ml-4 sm:pl-4 sm:border-l-2 sm:border-gray-200 sm:py-2 sm:mt-0 mt-4">
-          © 2024 kokura.ex —
+          © 2025 kokura.ex —
           <.link
             href="https://twitter.com/im_miolab"
             class="text-gray-500 ml-1"

--- a/app/mix.exs
+++ b/app/mix.exs
@@ -4,7 +4,7 @@ defmodule Kokuraex.MixProject do
   def project do
     [
       app: :kokuraex,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# About

- Update Elixir version from 1.18.1 to __1.18.3__ .
- Update copyright year to __2025__ .

## Ref

- https://github.com/miolab/kokuraex/pull/96
- https://github.com/elixir-lang/elixir/releases/tag/v1.18.2
- https://github.com/elixir-lang/elixir/releases/tag/v1.18.3
